### PR TITLE
Added required variable for prezto

### DIFF
--- a/prompt_garrett_setup
+++ b/prompt_garrett_setup
@@ -231,6 +231,9 @@ function prompt_garrett_setup {
   add-zsh-hook preexec prompt_garrett_preexec
   add-zsh-hook precmd prompt_garrett_precmd
   add-zsh-hook chpwd prompt_garrett_chpwd
+  
+  # Tell prezto we can manage this prompt
+  zstyle ':prezto:module:prompt' managed 'yes'
 
   #
   # Colors


### PR DESCRIPTION
New required variable for all prezto prompts (https://github.com/sorin-ionescu/prezto/tree/master/modules/prompt#required-variables)

Potentially fixes: https://github.com/chauncey-garrett/zsh-prompt-garrett/issues/32